### PR TITLE
Upgrade to Grouper Release

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,39 +15,33 @@ workspace(name = "multiple_edgetpu_demo")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-TENSORFLOW_COMMIT = "48c3bae94a8b324525b45f157d638dfd4e8c3be1"
+TENSORFLOW_COMMIT = "a4dfb8d1a71385bd6d122e4f27f86dcebb96712d"
 # Command to calculate: curl -L <FILE-URL> | sha256sum | awk '{print $1}'
-TENSORFLOW_SHA256 = "363420a67b4cfa271cd21e5c8fac0d7d91b18b02180671c3f943c887122499d8"
+TENSORFLOW_SHA256 = "cb99f136dc5c89143669888a44bfdd134c086e1e2d9e36278c1eb0f03fe62d76"
 
-# These values come from the Tensorflow workspace. If the TF commit is updated,
-# these should be updated to match.
-IO_BAZEL_RULES_CLOSURE_COMMIT = "308b05b2419edb5c8ee0471b67a40403df940149"
-IO_BAZEL_RULES_CLOSURE_SHA256 = "5b00383d08dd71f28503736db0500b6fb4dda47489ff5fc6bed42557c07c6ba9"
-
-CORAL_CROSSTOOL_COMMIT = "142e930ac6bf1295ff3ba7ba2b5b6324dfb42839"
-CORAL_CROSSTOOL_SHA256 = "088ef98b19a45d7224be13636487e3af57b1564880b67df7be8b3b7eee4a1bfc"
+CORAL_CROSSTOOL_COMMIT = "6bcc2261d9fc60dff386b557428d98917f0af491"
+CORAL_CROSSTOOL_SHA256 = "38cb4da13009d07ebc2fed4a9d055b0f914191b344dd2d1ca5803096343958b4"
 
 # Configure libedgetpu and downstream libraries (TF and Crosstool).
 http_archive(
   name = "libedgetpu",
-  sha256 = "d76d18c5a96758dd620057028cdd4e129bd885480087a5c7334070bba3797e58",
-  strip_prefix = "libedgetpu-14eee1a076aa1af7ec1ae3c752be79ae2604a708",
+  sha256 = "14d5527a943a25bc648c28a9961f954f70ba4d79c0a9ca5ae226e1831d72fe80",
+  strip_prefix = "libedgetpu-3164995622300286ef2bb14d7fdc2792dae045b7",
   urls = [
-    "https://github.com/google-coral/libedgetpu/archive/14eee1a076aa1af7ec1ae3c752be79ae2604a708.tar.gz"
+    "https://github.com/google-coral/libedgetpu/archive/3164995622300286ef2bb14d7fdc2792dae045b7.tar.gz"
   ],
 )
 
 load("@libedgetpu//:workspace.bzl", "libedgetpu_dependencies")
 libedgetpu_dependencies(TENSORFLOW_COMMIT, TENSORFLOW_SHA256,
-                        IO_BAZEL_RULES_CLOSURE_COMMIT,IO_BAZEL_RULES_CLOSURE_SHA256,
                         CORAL_CROSSTOOL_COMMIT,CORAL_CROSSTOOL_SHA256)
 
 http_archive(
   name = "libcoral",
-  sha256 = "ec0e1dfd4412b3c32f7ceac7b4507d0d084173229ef17f692a4ce95342731f58",
-  strip_prefix = "libcoral-982426546dfa10128376d0c24fd8a8b161daac97",
+  sha256 = "e41d71a080314734f73895539c05314caf028b63dc8172931b9eb12f7d01a62c",
+  strip_prefix = "libcoral-6589d0bb49c7fdbc4194ce178d06f8cdc7b5df60",
   urls = [
-    "https://github.com/google-coral/libcoral/archive/982426546dfa10128376d0c24fd8a8b161daac97.tar.gz"
+    "https://github.com/google-coral/libcoral/archive/6589d0bb49c7fdbc4194ce178d06f8cdc7b5df60.tar.gz"
   ],
 )
 
@@ -72,8 +66,17 @@ glog_library(with_gflags=0)
 """,
 )
 
-load("@org_tensorflow//tensorflow:workspace.bzl", "tf_workspace")
-tf_workspace(tf_repo_name = "org_tensorflow")
+load("@org_tensorflow//tensorflow:workspace3.bzl", "tf_workspace3")
+tf_workspace3()
+
+load("@org_tensorflow//tensorflow:workspace2.bzl", "tf_workspace2")
+tf_workspace2()
+
+load("@org_tensorflow//tensorflow:workspace1.bzl", "tf_workspace1")
+tf_workspace1()
+
+load("@org_tensorflow//tensorflow:workspace0.bzl", "tf_workspace0")
+tf_workspace0()
 
 load("@coral_crosstool//:configure.bzl", "cc_crosstool")
 cc_crosstool(name = "crosstool", additional_system_include_directories=["//docker/include"])

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get update && apt-get install -y \
   git \
   vim
 
-ARG BAZEL_VERSION=2.1.0
+ARG BAZEL_VERSION=4.0.0
 RUN wget -O /bazel https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh && \
     bash /bazel && \
     rm -f /bazel

--- a/src/BUILD
+++ b/src/BUILD
@@ -20,6 +20,7 @@ cc_binary(
         "@local//:gstreamer",
         "@local//:gstallocators",
         "@local//:gtk",
+        "@libcoral//coral:error_reporter",
         "@libcoral//coral/pipeline:pipelined_model_runner",
         "@libedgetpu//tflite/public:oss_edgetpu_direct_all",
         "@org_tensorflow//tensorflow/lite:framework",

--- a/src/BUILD
+++ b/src/BUILD
@@ -21,7 +21,6 @@ cc_binary(
         "@local//:gstallocators",
         "@local//:gtk",
         "@libcoral//coral/pipeline:pipelined_model_runner",
-        "@libcoral//coral/pipeline:utils",
         "@libedgetpu//tflite/public:oss_edgetpu_direct_all",
         "@org_tensorflow//tensorflow/lite:framework",
         "@org_tensorflow//tensorflow/lite/kernels:builtin_ops",

--- a/src/multiple_edgetpu_demo.cc
+++ b/src/multiple_edgetpu_demo.cc
@@ -37,6 +37,7 @@
 #include "absl/strings/str_split.h"
 #include "absl/strings/substitute.h"
 #include "absl/synchronization/mutex.h"
+#include "coral/error_reporter.h"
 #include "coral/pipeline/pipelined_model_runner.h"
 #include "glog/logging.h"
 #include "tensorflow/lite/interpreter.h"
@@ -217,7 +218,8 @@ class App {
 
  private:
   static std::unique_ptr<tflite::Interpreter> InitializeInterpreter(
-      tflite::FlatBufferModel *model, edgetpu::EdgeTpuContext *context);
+      tflite::FlatBufferModel *model, edgetpu::EdgeTpuContext *context,
+      coral::EdgeTpuErrorReporter *error_reporter);
 
   void InitializeInference();
   void InitializeGstreamer();
@@ -238,6 +240,7 @@ class App {
   std::vector<std::unique_ptr<tflite::Interpreter>> segment_interpreters_;
   std::unique_ptr<coral::PipelinedModelRunner> runner_;
   std::unique_ptr<tflite::Interpreter> interpreter_;
+  coral::EdgeTpuErrorReporter error_reporter_;
   std::deque<std::chrono::time_point<std::chrono::steady_clock>> start_times_;
   GstElement *pipeline_ = nullptr;
   GstElement *glsink_ = nullptr;
@@ -291,10 +294,11 @@ App::~App() {
 }
 
 std::unique_ptr<tflite::Interpreter> App::InitializeInterpreter(
-    tflite::FlatBufferModel *model, edgetpu::EdgeTpuContext *context) {
+    tflite::FlatBufferModel *model, edgetpu::EdgeTpuContext *context,
+    coral::EdgeTpuErrorReporter *error_reporter) {
   tflite::ops::builtin::BuiltinOpResolver resolver;
   resolver.AddCustom(edgetpu::kCustomOp, edgetpu::RegisterCustomOp());
-  tflite::InterpreterBuilder builder(model->GetModel(), resolver);
+  tflite::InterpreterBuilder builder(model->GetModel(), resolver, error_reporter);
   std::unique_ptr<tflite::Interpreter> interpreter;
   CHECK_EQ(builder(&interpreter), kTfLiteOk);
   interpreter->SetExternalContext(kTfLiteEdgeTpuContext, context);
@@ -343,8 +347,8 @@ void App::InitializeInference() {
   for (size_t i = 0; i < num_segments; ++i) {
     models_.push_back(CHECK_NOTNULL(tflite::FlatBufferModel::BuildFromFile(
         model_path_segments[i].c_str())));
-    segment_interpreters_[i] =
-        InitializeInterpreter(models_[i].get(), edgetpu_contexts_[i].get());
+      segment_interpreters_[i] = InitializeInterpreter(models_[i].get(),
+		      edgetpu_contexts_[i].get(), &error_reporter_);
     runner_interpreters[i] = segment_interpreters_[i].get();
     std::cout << model_path_segments[i] << " loaded" << std::endl;
   }
@@ -355,7 +359,8 @@ void App::InitializeInference() {
   models_.push_back(CHECK_NOTNULL(
       tflite::FlatBufferModel::BuildFromFile(full_model_path.c_str())));
   interpreter_ = InitializeInterpreter(models_.back().get(),
-                                       edgetpu_contexts_[pci_index].get());
+                                       edgetpu_contexts_[pci_index].get(),
+				       &error_reporter_);
   std::cout << "Full model " << full_model_path << " loaded for "
             << all_tpus[pci_index].path << std::endl;
 
@@ -652,6 +657,7 @@ GstFlowReturn App::OnNewSample(GstElement *element) {
         runner_->GetInputTensorAllocator()->Alloc(input_tensor->bytes);
     input_buffer.type = input_tensor->type;
     input_buffer.bytes = input_tensor->bytes;
+    input_buffer.name = input_tensor->name;
 
     CHECK(runner_->Push({input_buffer}).ok());
     mutex_.Lock();
@@ -754,7 +760,7 @@ void App::FeedInterpreter() {
       CHECK_EQ(tensor->data.raw, reinterpret_cast<char *>(info.data));
       gst_buffer_unmap(buffer, &info);
 
-      CHECK_EQ(interpreter_->Invoke(), kTfLiteOk);
+      CHECK_EQ(interpreter_->Invoke(), kTfLiteOk) << error_reporter_.message();
       std::chrono::duration<double, std::milli> inference_ms =
           std::chrono::steady_clock::now() - start_time;
       mutex_.Lock();


### PR DESCRIPTION
Upgrades the repo to work with the latest ML release, Grouper. This is
accomplished by:
* Updating dependecy commits.
* Changing tensorflow_workspace to the new 2.5.0 method.
* Upgrading Bazel to version 4.0.0
* Replacing small Pipeline API changes (Push/Pop uses absl::Status vs
bool and FreeTensors has been removed).